### PR TITLE
Throw if data > buffer size ref'd, or invalid offset, and stop sparse applying to array elements

### DIFF
--- a/msgpack.js
+++ b/msgpack.js
@@ -62,7 +62,8 @@ function Decoder(buffer, offset) {
   this.bufferLength = buffer.length
 }
 Decoder.prototype.map = function (length) {
-  if(length > this.bufferLength) {
+  /* minimal map: every key and value is one byte */
+  if((length * 2) > this.bufferLength) {
     throw new Error(`malformed messagepack detected: buffer size was ${this.bufferLength}, but referenced a map of length ${length})`);
   }
   var value = {};
@@ -101,6 +102,11 @@ Decoder.prototype.array = function (length) {
 Decoder.prototype.parse = function () {
   var type = this.buffer[this.offset];
   var value, length, extType;
+
+  if (type === undefined) {
+    throw new Error('malformed messagepack (referenced offset is outside buffer)');
+  }
+
   // Positive FixInt
   if ((type & 0x80) === 0x00) {
     this.offset++;

--- a/msgpack.js
+++ b/msgpack.js
@@ -59,8 +59,12 @@ function writeUInt64BE(buf, val, offset) {
 function Decoder(buffer, offset) {
   this.offset = offset || 0;
   this.buffer = buffer;
+  this.bufferLength = buffer.length
 }
 Decoder.prototype.map = function (length) {
+  if(length > this.bufferLength) {
+    throw new Error(`malformed messagepack detected: buffer size was ${this.bufferLength}, but referenced a map of length ${length})`);
+  }
   var value = {};
   for (var i = 0; i < length; i++) {
     var key = this.parse();
@@ -69,16 +73,25 @@ Decoder.prototype.map = function (length) {
   return value;
 };
 Decoder.prototype.bin = Decoder.prototype.buf = function (length) {
+  if(length > this.bufferLength) {
+    throw new Error(`malformed messagepack detected: buffer size was ${this.bufferLength}, but referenced a binary of length ${length})`);
+  }
   var value = bops.subarray(this.buffer, this.offset, this.offset + length);
   this.offset += length;
   return value;
 };
 Decoder.prototype.str = function (length) {
+  if(length > this.bufferLength) {
+    throw new Error(`malformed messagepack detected: buffer size was ${this.bufferLength}, but referenced a string of length ${length})`);
+  }
   var value = bops.to(bops.subarray(this.buffer, this.offset, this.offset + length));
   this.offset += length;
   return value;
 };
 Decoder.prototype.array = function (length) {
+  if(length > this.bufferLength) {
+    throw new Error(`malformed messagepack detected: buffer size was ${this.bufferLength}, but referenced an array of length ${length})`);
+  }
   var value = new Array(length);
   for (var i = 0; i < length; i++) {
     value[i] = this.parse();

--- a/test.js
+++ b/test.js
@@ -82,3 +82,12 @@ test('returns undefined for a function', function (assert) {
   assert.equal(msgpack.encode(noop), JSON.stringify(noop))
   assert.end()
 })
+
+test('sparse flag discards undefined values in objects; keeps them in arrays', function (assert) {
+  const input = [undefined, {a: 'b', 'c': undefined}, undefined];
+  const output = msgpack.decode(msgpack.encode(input, true));
+  assert.equal(output[0], undefined);
+  assert.equal(output.length, 3);
+  assert.deepEqual(output[1], {a: 'b'});
+  assert.end()
+})


### PR DESCRIPTION
Additionally to the check suggested in https://github.com/ably/realtime/issues/1295#issuecomment-334401010 , added a clause to trap invalid offsets, or they get caught in the Positive FixInt clause (as `type` is `undefined` and `(undefined & 0x80) === 0x00` because javascript)
```
  // Positive FixInt
  if ((type & 0x80) === 0x00) {
    this.offset++;
    return type;
  }
```

Also stopped the sparse flag applying to arrays, which work as expected now.

I think with these changes we shouldn't need a fixed max length.