### PR TITLE
update bops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
-  "name": "msgpack-js",
+  "name": "@ably/msgpack-js",
   "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+      "integrity": "sha1-R0IRyV5s8qVH20YeT2d4tR0I+mU="
     },
     "bops": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.7.tgz",
-      "integrity": "sha1-tKClqDmkBkVK8P4FqLkaenZqVOI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
+      "integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
       "requires": {
-        "base64-js": "0.0.2",
+        "base64-js": "1.0.2",
         "to-utf8": "0.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository": "ably-forks/msgpack-js",
   "main": "msgpack.js",
   "dependencies": {
-    "bops": "~0.0.6"
+    "bops": "^1.0.1"
   },
   "devDependencies": {
     "tape": "~1.0.2"


### PR DESCRIPTION
A number of buffer commands have been deprecated since earlier versions of node. On node 12 we see overhead with node internals checking deprecated buffer functions. Mainline has already merged these changes. PR-ing from my own fork because I don't have access to this repo.