### PR TITLE
Fallback to floats for numbers too large to represent as uint64

### DIFF
--- a/msgpack.js
+++ b/msgpack.js
@@ -414,7 +414,10 @@ function encode(value, buffer, offset, sparse, isMapElement) {
         writeUInt64BE(buffer, value, offset + 1);
         return 9;
       }
-      throw new Error("Number too big 0x" + value.toString(16));
+      // bigger than representable as uint64, so fallback to double
+      buffer[offset] =  0xcb;
+      bops.writeDoubleBE(buffer, value, offset + 1);
+      return 9;
     }
     // negative fixnum
     if (value >= -0x20) {
@@ -445,7 +448,10 @@ function encode(value, buffer, offset, sparse, isMapElement) {
       writeInt64BE(buffer, value, offset + 1);
       return 9;
     }
-    throw new Error("Number too small -0x" + value.toString(16).substr(1));
+    // bigger than representable as uint64, so fallback to double
+    buffer[offset] =  0xcb;
+    bops.writeDoubleBE(buffer, value, offset + 1);
+    return 9;
   }
 
   if (type === "undefined") {
@@ -576,7 +582,8 @@ function sizeof(value, sparse, isMapElement) {
       if (value < 0x100000000) return 5;
       // uint 64
       if (value < 0x10000000000000000) return 9;
-      throw new Error("Number too big 0x" + value.toString(16));
+      // fallback to double
+      return 9
     }
     // negative fixnum
     if (value >= -0x20) return 1;
@@ -588,7 +595,8 @@ function sizeof(value, sparse, isMapElement) {
     if (value >= -0x80000000) return 5;
     // int 64
     if (value >= -0x8000000000000000) return 9;
-    throw new Error("Number too small -0x" + value.toString(16).substr(1));
+    // fallback to double
+    return 9
   }
 
   // Boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,60 +1,83 @@
 {
   "name": "@ably/msgpack-js",
   "version": "0.4.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "base64-js": {
+  "packages": {
+    "": {
+      "name": "@ably/msgpack-js",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bops": "^1.0.1"
+      },
+      "devDependencies": {
+        "tape": "~1.0.2"
+      }
+    },
+    "node_modules/base64-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
-      "integrity": "sha1-R0IRyV5s8qVH20YeT2d4tR0I+mU="
+      "integrity": "sha1-R0IRyV5s8qVH20YeT2d4tR0I+mU=",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "bops": {
+    "node_modules/bops": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
       "integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
-      "requires": {
+      "dependencies": {
         "base64-js": "1.0.2",
         "to-utf8": "0.0.1"
       }
     },
-    "deep-equal": {
+    "node_modules/deep-equal": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
       "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "defined": {
+    "node_modules/defined": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
       "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
       "dev": true
     },
-    "jsonify": {
+    "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "tape": {
+    "node_modules/tape": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tape/-/tape-1.0.4.tgz",
       "integrity": "sha1-4ujlxt0/AP3CpeRRT2L8Ih5Z+cQ=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "deep-equal": "~0.0.0",
         "defined": "~0.0.0",
         "jsonify": "~0.0.0",
         "through": "~2.3.4"
+      },
+      "bin": {
+        "tape": "bin/tape"
       }
     },
-    "through": {
+    "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "to-utf8": {
+    "node_modules/to-utf8": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
       "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="

--- a/test.js
+++ b/test.js
@@ -91,3 +91,10 @@ test('sparse flag discards undefined values in objects; keeps them in arrays', f
   assert.deepEqual(output[1], {a: 'b'});
   assert.end()
 })
+
+test('Can encode large floats', function (assert) {
+  const input = 1.7e+308
+  const output = msgpack.decode(msgpack.encode(input, true));
+  assert.equal(input, output);
+  assert.end()
+})


### PR DESCRIPTION
Why wouldn't we do this? If someone calls encode with number >2^64 clearly they're starting with a float so why would we reject it because it's not representable as uint64?

(ideally we'd be able to force a particular numeric type, but this is better than the status quo)