### PR TITLE
fix: encode undefined as nil instead of fixext 1

### DIFF
--- a/msgpack.js
+++ b/msgpack.js
@@ -46,14 +46,22 @@ function writeUInt64BE(buf, val, offset) {
 
 // https://gist.github.com/frsyuki/5432559 - v5 spec
 //
-// I've used one extension point from `fixext 1` to store `undefined`. On the wire this
-// should translate to exactly 0xd40000 
+// undefined handling:
 //
-// +--------+--------+--------+
-// |  0xd4  |  0x00  |  0x00  |
-// +--------+--------+--------+
-//    ^ fixext |        ^ value part unused (fixed to be 0)
-//             ^ indicates undefined value
+// Previously, `undefined` was encoded using a custom fixext 1 extension
+// (0xd4 0x00 0x00). This is non-standard msgpack and causes decode failures
+// in other languages' msgpack decoders (e.g. Go's vmihailenco/msgpack),
+// which don't recognise extension type 0 and reject the payload with a
+// "cannot decode" error.
+//
+// `undefined` is now encoded as nil (0xc0), the standard msgpack
+// representation of "no value". This matches JSON.stringify's behaviour
+// of collapsing undefined to null, and is understood by every conforming
+// msgpack decoder.
+//
+// The decoder still accepts the legacy fixext 1 encoding (0xd4 0x00 0x00)
+// so that data written by older versions can still be read. New data will
+// always use nil.
 //
 
 function Decoder(buffer, offset) {
@@ -234,7 +242,10 @@ Decoder.prototype.parse = function () {
     this.offset += 9;
     return value;
 
-  // fixext 1 / undefined
+  // fixext 1 — legacy encoding for undefined (0xd4 0x00 0x00).
+  // New versions encode undefined as nil (0xc0), but we still accept the
+  // old fixext 1 format here for backwards compatibility with data that was
+  // written by previous versions of this library.
   case 0xd4:
     extType = bops.readUInt8(this.buffer, this.offset + 1);
     value = bops.readUInt8(this.buffer, this.offset + 2);
@@ -454,12 +465,15 @@ function encode(value, buffer, offset, sparse, isMapElement) {
     return 9;
   }
 
+  // undefined → nil (0xc0). This uses the standard msgpack nil type rather
+  // than the legacy fixext 1 encoding (0xd4 0x00 0x00) which is not
+  // recognised by non-JS msgpack decoders (Go, Python, Ruby, etc.).
+  // On decode, nil returns null — matching JSON.stringify/parse behaviour
+  // where undefined is not a round-trippable value.
   if (type === "undefined") {
     if(sparse && isMapElement) return 0;
-    buffer[offset] = 0xd4;
-    buffer[offset + 1] = 0x00; // fixext special type/value
-    buffer[offset + 2] = 0x00;
-    return 3;
+    buffer[offset] = 0xc0;
+    return 1;
   }
 
   // null
@@ -602,9 +616,9 @@ function sizeof(value, sparse, isMapElement) {
   // Boolean
   if (type === "boolean") return 1;
 
-  // undefined, null
+  // undefined and null both encode as nil (0xc0), 1 byte
   if (value === null) return (sparse && isMapElement) ? 0 : 1;
-  if (value === undefined) return (sparse && isMapElement) ? 0 : 3;
+  if (value === undefined) return (sparse && isMapElement) ? 0 : 1;
 
   if('function' === typeof value.toJSON)
     return sizeof(value.toJSON(), sparse)

--- a/test.js
+++ b/test.js
@@ -4,8 +4,11 @@ var test = require('tape');
 var msgpack = require('./msgpack');
 var util = require('util');
 
+// undefined is deliberately excluded from the round-trip list because it now
+// encodes as nil (0xc0) and decodes back as null — it is not round-trippable.
+// Dedicated tests below verify the encoding and decoding behaviour explicitly.
 var tests = [
-  true, false, null, undefined,
+  true, false, null,
   0, 1, -1, 2, -2, 4, -4, 6, -6,
   0x10, -0x10, 0x20, -0x20, 0x40, -0x40,
   0x80, -0x80, 0x100, -0x100, 0x200, -0x100,
@@ -86,7 +89,9 @@ test('returns undefined for a function', function (assert) {
 test('sparse flag discards undefined values in objects; keeps them in arrays', function (assert) {
   const input = [undefined, {a: 'b', 'c': undefined}, undefined];
   const output = msgpack.decode(msgpack.encode(input, true));
-  assert.equal(output[0], undefined);
+  // Array elements encode as nil (0xc0) and decode as null — undefined is
+  // not representable in standard msgpack, so null is the closest equivalent.
+  assert.equal(output[0], null);
   assert.equal(output.length, 3);
   assert.deepEqual(output[1], {a: 'b'});
   assert.end()
@@ -96,5 +101,72 @@ test('Can encode large floats', function (assert) {
   const input = 1.7e+308
   const output = msgpack.decode(msgpack.encode(input, true));
   assert.equal(input, output);
+  assert.end()
+})
+
+// --- undefined encoding tests ---
+//
+// undefined is now encoded as standard msgpack nil (0xc0) instead of the
+// legacy fixext 1 (0xd4 0x00 0x00). This ensures interoperability with
+// non-JS msgpack decoders (Go, Python, Ruby, etc.) that reject unknown
+// extension types.
+
+test('undefined encodes as nil (0xc0), not fixext 1', function (assert) {
+  var encoded = msgpack.encode(undefined);
+  // nil is a single byte: 0xc0
+  assert.equal(encoded.length, 1, 'nil encoding is 1 byte');
+  assert.equal(encoded[0], 0xc0, 'byte is 0xc0 (nil)');
+  assert.end()
+})
+
+test('undefined decodes as null (same as JSON.stringify/parse)', function (assert) {
+  var encoded = msgpack.encode(undefined);
+  var decoded = msgpack.decode(encoded);
+  assert.equal(decoded, null, 'undefined round-trips as null');
+  assert.end()
+})
+
+test('undefined values in objects encode as nil, not fixext 1', function (assert) {
+  var input = { a: 1, b: undefined, c: 'hello' };
+  var encoded = msgpack.encode(input);
+  // Verify no fixext 1 bytes (0xd4) appear in the output
+  for (var i = 0; i < encoded.length; i++) {
+    assert.notEqual(encoded[i], 0xd4, 'no fixext 1 byte at offset ' + i);
+  }
+  var decoded = msgpack.decode(encoded);
+  assert.equal(decoded.a, 1);
+  assert.equal(decoded.b, null, 'undefined map value decodes as null');
+  assert.equal(decoded.c, 'hello');
+  assert.end()
+})
+
+test('legacy fixext 1 encoding (0xd4 0x00 0x00) still decodes as undefined', function (assert) {
+  // Simulate data written by a previous version of this library where
+  // undefined was encoded as fixext 1 (type=0, value=0)
+  var legacyBuffer = bops.from([0xd4, 0x00, 0x00]);
+  var decoded = msgpack.decode(legacyBuffer);
+  assert.equal(decoded, undefined, 'legacy fixext 1 still decodes as undefined');
+  assert.end()
+})
+
+test('nested objects with undefined values are interoperable', function (assert) {
+  // This is the exact pattern that caused failures with Go's msgpack decoder:
+  // a nested object with undefined values in a PUT request body
+  var input = {
+    message: {
+      text: 'updated message',
+      metadata: undefined,
+      headers: undefined
+    }
+  };
+  var encoded = msgpack.encode(input);
+  // Verify no fixext 1 bytes appear anywhere in the output
+  for (var i = 0; i < encoded.length; i++) {
+    assert.notEqual(encoded[i], 0xd4, 'no fixext 1 byte at offset ' + i);
+  }
+  var decoded = msgpack.decode(encoded);
+  assert.equal(decoded.message.text, 'updated message');
+  assert.equal(decoded.message.metadata, null, 'nested undefined decodes as null');
+  assert.equal(decoded.message.headers, null, 'nested undefined decodes as null');
   assert.end()
 })


### PR DESCRIPTION
## Summary

Encode `undefined` as standard msgpack nil (`0xc0`) instead of a custom fixext 1 extension (`0xd4 0x00 0x00`).

The fixext 1 encoding is non-standard and causes "cannot decode request body" errors in non-JS msgpack decoders (Go, Python, Ruby, etc.) that do not recognise extension type 0.

## Why fixext 1 existed in the first place

The history goes through three eras:

- 2010 (original): msgpack v4 had an unused byte `0xc4`. The library used it to store `undefined`, a JS-only concept with no msgpack equivalent. This was a 1-byte encoding.
- 2013 (commit `128e53d`): The msgpack v5 spec reclaimed `0xc4` for `bin 8`. The author needed a new home for `undefined` and chose `fixext 1` with type=0 (`0xd4 0x00 0x00`), since the extension type system was designed for implementation-defined custom types. Reasonable choice at the time.
- 2014 (commit `084c5b9`): The `sparse` flag was added to optionally skip `undefined`/`null` values in maps, suggesting the encoding was already causing problems.

The intent was to preserve JavaScript's `undefined` vs `null` distinction during round-tripping, something no other language's msgpack implementation needs or does.

## Does this break ably-js?

The short answer is no.

Data decoded by ably-js comes from the Ably server, which uses Go/Erlang msgpack. The server never produces fixext 1 (`0xd4 0x00 0x00`). It sends nil (`0xc0`) for null values, or omits fields entirely for absent values. Our change only affects the encoder (what ably-js sends). The decoder's fixext 1 handler is kept for backwards compat but is never triggered by server data.

| Data flow | Affected? | Why |
|-----------|-----------|-----|
| Server to ably-js (WebSocket protocol messages) | No | Server uses standard msgpack, never sends fixext 1 |
| Server to ably-js (REST API responses) | No | Same reason |
| ably-js to Server (requests/protocol) | Yes, positively | nil is understood by all decoders |
| ably-js encode then ably-js decode (tests) | Yes | `undefined` round-trips as `null` instead of `undefined` |

Code in ably-js that checks `=== undefined` on decoded data (Live Objects, presence, messages, etc.) is not affected because that data originates from the server, not from this library's encoder.

## What does change

1. Round-trip semantics in tests: `encode(undefined)` then `decode(...)` now gives `null` instead of `undefined`. Only affects test assertions, not production data flows.
2. Explicit `undefined` properties in outbound objects: if ably-js sends `{ foo: undefined }` via msgpack, the server now receives `{ foo: null }` instead of an undecodable fixext 1. This is strictly better.
3. The browser has a separate copy: `src/platform/web/lib/util/msgpack.ts` in ably-js has its own fixext 1 encoding. This fix only covers the Node.js path via `@ably/msgpack-js`. The browser bundle would need a matching change in the ably-js repo for full consistency.

## Pros

- Fixes interop with every non-JS msgpack decoder (Go, Python, Ruby, C, etc.)
- Eliminates an entire class of "cannot decode request body" bugs
- Matches JSON.stringify/parse semantics (undefined collapses to null)
- Produces smaller payloads (1 byte vs 3)
- Uses standard msgpack with no custom extension types
- Backwards-compatible decoder (old fixext 1 data still reads)

## Cons

- `undefined` no longer round-trips through msgpack (becomes `null`), but this only matters for JS-to-JS msgpack where both sides use this library, and even then relying on the `undefined` vs `null` distinction in serialized data is fragile
- Browser bundle in ably-js needs a separate matching fix for cross-platform consistency
- Technically a semver-breaking change for anyone relying on `encode(undefined)` then `decode` returning `undefined`

## Context

The Ably Chat SDK's integration tests fail when `useBinaryProtocol: true` because `messages.update()` (a PUT request) sends an object with `undefined` values. The `@ably/msgpack-js` encoder writes these as fixext 1, and Go's `vmihailenco/msgpack` decoder rejects the payload. See: https://github.com/ably/ably-chat-js/pull/721

## Test plan

- [x] All existing tests pass (with updated expectations for undefined-as-null)
- [x] New tests verify nil encoding, null decode, no fixext 1 in output, legacy fixext 1 backwards compat, and the exact nested-object pattern that triggered the Go decode failure